### PR TITLE
Add name-based operations to task tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,32 +136,55 @@ Create a new task.
 ```
 
 ### omnifocus_complete_task
-Mark a task as complete or dropped.
+Mark a task as complete or dropped. Can use either task ID or task name.
 ```json
 {
   "taskId": "abc123",
   "action": "complete"
 }
 ```
-Action can be `"complete"` (default) or `"drop"`.
+Or by name:
+```json
+{
+  "taskName": "Write documentation",
+  "action": "complete"
+}
+```
+Action can be `"complete"` (default) or `"drop"`. If both `taskId` and `taskName` are provided, `taskId` takes priority.
 
 ### omnifocus_add_tag_to_task
-Add a tag to a task.
+Add a tag to a task. Can use either task ID or task name.
 ```json
 {
   "taskId": "abc123",
   "tagName": "Urgent"
 }
 ```
+Or by name:
+```json
+{
+  "taskName": "Write report",
+  "tagName": "Urgent"
+}
+```
+If both `taskId` and `taskName` are provided, `taskId` takes priority.
 
 ### omnifocus_remove_tag_from_task
-Remove a tag from a task.
+Remove a tag from a task. Can use either task ID or task name.
 ```json
 {
   "taskId": "abc123",
   "tagName": "Urgent"
 }
 ```
+Or by name:
+```json
+{
+  "taskName": "Write report",
+  "tagName": "Urgent"
+}
+```
+If both `taskId` and `taskName` are provided, `taskId` takes priority.
 
 ### omnifocus_search
 Search across OmniFocus.

--- a/src/index.ts
+++ b/src/index.ts
@@ -724,11 +724,18 @@ Examples:
 
 const CompleteTaskInputSchema = z.object({
   taskId: z.string()
-    .describe("The task ID (primaryKey) to update"),
+    .optional()
+    .describe("The task ID (primaryKey) to update - takes priority if both taskId and taskName provided"),
+  taskName: z.string()
+    .optional()
+    .describe("The task name to search for - used if taskId not provided"),
   action: z.enum(["complete", "drop"])
     .default("complete")
     .describe("Action to perform: 'complete' marks the task done, 'drop' marks it as dropped/cancelled")
-}).strict();
+}).strict().refine(
+  (data) => data.taskId || data.taskName,
+  { message: "Either taskId or taskName must be provided" }
+);
 
 server.registerTool(
   "omnifocus_complete_task",
@@ -736,18 +743,22 @@ server.registerTool(
     title: "Complete or Drop Task",
     description: `Mark a task as complete or dropped in OmniFocus.
 
-Use the task ID from list or search results.
+Use the task ID from list or search results, or provide a task name.
 
 Args:
-  - taskId (string): The task's ID (primaryKey)
+  - taskId (string): The task's ID (primaryKey) - takes priority if both provided
+  - taskName (string): The task name to search for - used if taskId not provided
   - action (string): 'complete' (default) or 'drop'
+
+At least one of taskId or taskName must be provided.
 
 Returns:
   The updated task object
 
 Examples:
-  - Complete a task: { taskId: "abc123" }
-  - Drop a task: { taskId: "abc123", action: "drop" }`,
+  - Complete by ID: { taskId: "abc123" }
+  - Complete by name: { taskName: "Write documentation" }
+  - Drop by name: { taskName: "Old task", action: "drop" }`,
     inputSchema: CompleteTaskInputSchema,
     annotations: {
       readOnlyHint: false,
@@ -757,16 +768,56 @@ Examples:
     }
   },
   async (params) => {
-    const { taskId, action } = params;
+    const { taskId, taskName, action } = params;
 
     const actionCode = action === "drop"
       ? "task.markDropped();"
       : "task.markComplete();";
 
+    let findTaskCode: string;
+    if (taskId) {
+      findTaskCode = `
+        var task = doc.flattenedTasks().find(function(t) { return t.id() === "${taskId}"; });
+        if (!task) { throw new Error("Task not found with ID: ${taskId}"); }
+      `;
+    } else {
+      // taskName must be provided due to schema validation
+      const escapedName = taskName!.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+      findTaskCode = `
+        var searchName = "${escapedName}";
+        var exactMatches = doc.flattenedTasks().filter(function(t) {
+          return t.name() === searchName;
+        });
+
+        if (exactMatches.length === 1) {
+          var task = exactMatches[0];
+        } else if (exactMatches.length > 1) {
+          var matchList = exactMatches.slice(0, 10).map(function(t) {
+            return "- " + t.name() + " (ID: " + t.id() + ", Project: " + (t.containingProject() ? t.containingProject().name() : "Inbox") + ")";
+          }).join("\\n");
+          throw new Error("Multiple tasks found with exact name '${escapedName}'. Please use taskId instead:\\n" + matchList);
+        } else {
+          var partialMatches = doc.flattenedTasks().filter(function(t) {
+            return t.name().toLowerCase().indexOf(searchName.toLowerCase()) !== -1;
+          });
+
+          if (partialMatches.length === 0) {
+            throw new Error("No tasks found matching name: ${escapedName}");
+          } else if (partialMatches.length === 1) {
+            var task = partialMatches[0];
+          } else {
+            var matchList = partialMatches.slice(0, 10).map(function(t) {
+              return "- " + t.name() + " (ID: " + t.id() + ", Project: " + (t.containingProject() ? t.containingProject().name() : "Inbox") + ")";
+            }).join("\\n");
+            throw new Error("Multiple tasks found matching '${escapedName}'. Please use taskId or be more specific:\\n" + matchList);
+          }
+        }
+      `;
+    }
+
     const script = `
       ${TASK_MAPPER}
-      var task = doc.flattenedTasks().find(function(t) { return t.id() === "${taskId}"; });
-      if (!task) { throw new Error("Task not found with ID: ${taskId}"); }
+      ${findTaskCode}
       ${actionCode}
       JSON.stringify(mapTask(task));
     `;
@@ -796,10 +847,17 @@ Examples:
 
 const AddTagInputSchema = z.object({
   taskId: z.string()
-    .describe("The task ID to add the tag to"),
+    .optional()
+    .describe("The task ID to add the tag to - takes priority if both taskId and taskName provided"),
+  taskName: z.string()
+    .optional()
+    .describe("The task name to search for - used if taskId not provided"),
   tagName: z.string()
     .describe("The name of the tag to add")
-}).strict();
+}).strict().refine(
+  (data) => data.taskId || data.taskName,
+  { message: "Either taskId or taskName must be provided" }
+);
 
 server.registerTool(
   "omnifocus_add_tag_to_task",
@@ -808,14 +866,18 @@ server.registerTool(
     description: `Add a tag to a task in OmniFocus.
 
 Args:
-  - taskId (string): The task's ID
+  - taskId (string): The task's ID - takes priority if both provided
+  - taskName (string): The task name to search for - used if taskId not provided
   - tagName (string): Name of the tag to add
+
+At least one of taskId or taskName must be provided.
 
 Returns:
   The updated task object
 
 Examples:
-  - { taskId: "abc123", tagName: "Urgent" }`,
+  - By ID: { taskId: "abc123", tagName: "Urgent" }
+  - By name: { taskName: "Write report", tagName: "Urgent" }`,
     inputSchema: AddTagInputSchema,
     annotations: {
       readOnlyHint: false,
@@ -825,13 +887,53 @@ Examples:
     }
   },
   async (params) => {
-    const { taskId, tagName } = params;
+    const { taskId, taskName, tagName } = params;
     const escapeTagName = tagName.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+    let findTaskCode: string;
+    if (taskId) {
+      findTaskCode = `
+        var task = doc.flattenedTasks().find(function(t) { return t.id() === "${taskId}"; });
+        if (!task) { throw new Error("Task not found with ID: ${taskId}"); }
+      `;
+    } else {
+      // taskName must be provided due to schema validation
+      const escapedName = taskName!.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+      findTaskCode = `
+        var searchName = "${escapedName}";
+        var exactMatches = doc.flattenedTasks().filter(function(t) {
+          return t.name() === searchName;
+        });
+
+        if (exactMatches.length === 1) {
+          var task = exactMatches[0];
+        } else if (exactMatches.length > 1) {
+          var matchList = exactMatches.slice(0, 10).map(function(t) {
+            return "- " + t.name() + " (ID: " + t.id() + ", Project: " + (t.containingProject() ? t.containingProject().name() : "Inbox") + ")";
+          }).join("\\n");
+          throw new Error("Multiple tasks found with exact name '${escapedName}'. Please use taskId instead:\\n" + matchList);
+        } else {
+          var partialMatches = doc.flattenedTasks().filter(function(t) {
+            return t.name().toLowerCase().indexOf(searchName.toLowerCase()) !== -1;
+          });
+
+          if (partialMatches.length === 0) {
+            throw new Error("No tasks found matching name: ${escapedName}");
+          } else if (partialMatches.length === 1) {
+            var task = partialMatches[0];
+          } else {
+            var matchList = partialMatches.slice(0, 10).map(function(t) {
+              return "- " + t.name() + " (ID: " + t.id() + ", Project: " + (t.containingProject() ? t.containingProject().name() : "Inbox") + ")";
+            }).join("\\n");
+            throw new Error("Multiple tasks found matching '${escapedName}'. Please use taskId or be more specific:\\n" + matchList);
+          }
+        }
+      `;
+    }
 
     const script = `
       ${TASK_MAPPER}
-      var task = doc.flattenedTasks().find(function(t) { return t.id() === "${taskId}"; });
-      if (!task) { throw new Error("Task not found with ID: ${taskId}"); }
+      ${findTaskCode}
 
       var tag = doc.flattenedTags().find(function(t) { return t.name() === "${escapeTagName}"; });
       if (!tag) { throw new Error("Tag not found: ${escapeTagName}"); }
@@ -869,10 +971,17 @@ Examples:
 
 const RemoveTagInputSchema = z.object({
   taskId: z.string()
-    .describe("The task ID to remove the tag from"),
+    .optional()
+    .describe("The task ID to remove the tag from - takes priority if both taskId and taskName provided"),
+  taskName: z.string()
+    .optional()
+    .describe("The task name to search for - used if taskId not provided"),
   tagName: z.string()
     .describe("The name of the tag to remove")
-}).strict();
+}).strict().refine(
+  (data) => data.taskId || data.taskName,
+  { message: "Either taskId or taskName must be provided" }
+);
 
 server.registerTool(
   "omnifocus_remove_tag_from_task",
@@ -881,14 +990,18 @@ server.registerTool(
     description: `Remove a tag from a task in OmniFocus.
 
 Args:
-  - taskId (string): The task's ID
+  - taskId (string): The task's ID - takes priority if both provided
+  - taskName (string): The task name to search for - used if taskId not provided
   - tagName (string): Name of the tag to remove
+
+At least one of taskId or taskName must be provided.
 
 Returns:
   The updated task object
 
 Examples:
-  - { taskId: "abc123", tagName: "Urgent" }`,
+  - By ID: { taskId: "abc123", tagName: "Urgent" }
+  - By name: { taskName: "Write report", tagName: "Urgent" }`,
     inputSchema: RemoveTagInputSchema,
     annotations: {
       readOnlyHint: false,
@@ -898,13 +1011,53 @@ Examples:
     }
   },
   async (params) => {
-    const { taskId, tagName } = params;
+    const { taskId, taskName, tagName } = params;
     const escapeTagName = tagName.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+    let findTaskCode: string;
+    if (taskId) {
+      findTaskCode = `
+        var task = doc.flattenedTasks().find(function(t) { return t.id() === "${taskId}"; });
+        if (!task) { throw new Error("Task not found with ID: ${taskId}"); }
+      `;
+    } else {
+      // taskName must be provided due to schema validation
+      const escapedName = taskName!.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+      findTaskCode = `
+        var searchName = "${escapedName}";
+        var exactMatches = doc.flattenedTasks().filter(function(t) {
+          return t.name() === searchName;
+        });
+
+        if (exactMatches.length === 1) {
+          var task = exactMatches[0];
+        } else if (exactMatches.length > 1) {
+          var matchList = exactMatches.slice(0, 10).map(function(t) {
+            return "- " + t.name() + " (ID: " + t.id() + ", Project: " + (t.containingProject() ? t.containingProject().name() : "Inbox") + ")";
+          }).join("\\n");
+          throw new Error("Multiple tasks found with exact name '${escapedName}'. Please use taskId instead:\\n" + matchList);
+        } else {
+          var partialMatches = doc.flattenedTasks().filter(function(t) {
+            return t.name().toLowerCase().indexOf(searchName.toLowerCase()) !== -1;
+          });
+
+          if (partialMatches.length === 0) {
+            throw new Error("No tasks found matching name: ${escapedName}");
+          } else if (partialMatches.length === 1) {
+            var task = partialMatches[0];
+          } else {
+            var matchList = partialMatches.slice(0, 10).map(function(t) {
+              return "- " + t.name() + " (ID: " + t.id() + ", Project: " + (t.containingProject() ? t.containingProject().name() : "Inbox") + ")";
+            }).join("\\n");
+            throw new Error("Multiple tasks found matching '${escapedName}'. Please use taskId or be more specific:\\n" + matchList);
+          }
+        }
+      `;
+    }
 
     const script = `
       ${TASK_MAPPER}
-      var task = doc.flattenedTasks().find(function(t) { return t.id() === "${taskId}"; });
-      if (!task) { throw new Error("Task not found with ID: ${taskId}"); }
+      ${findTaskCode}
 
       var tagOnTask = task.tags().find(function(t) { return t.name() === "${escapeTagName}"; });
       if (tagOnTask) {


### PR DESCRIPTION
Enhance omnifocus_complete_task, omnifocus_add_tag_to_task, and omnifocus_remove_tag_from_task to accept both task IDs and task names.

## Features
- Each tool now accepts optional taskId and taskName parameters
- taskId takes priority if both are provided
- Schema validation ensures at least one parameter is provided
- Smart matching: exact match first, then case-insensitive partial match
- Disambiguation: returns helpful error with match list if multiple tasks found
- Updated README.md with examples for both ID and name-based usage

This makes the tools more user-friendly for AI interactions where users naturally reference tasks by name rather than looking up IDs.

Fixes #8

Generated with [Claude Code](https://claude.ai/code)