### PR TITLE
Add subtask support to OmniFocus MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This MCP server provides access to OmniFocus functionality:
 ### Task Management
 - **List inbox tasks** - View and filter tasks in your inbox
 - **Create tasks** - Add new tasks with full property support (due dates, tags, notes, etc.)
+- **Create subtasks** - Create tasks as children of other tasks (hierarchical structure)
+- **Get subtasks** - Retrieve all subtasks for a given task (with recursive option)
 - **Complete/Drop tasks** - Mark tasks as done or dropped
 - **Get due tasks** - Find tasks due within a timeframe
 - **Get flagged tasks** - List all flagged items
@@ -135,6 +137,15 @@ Create a new task.
 }
 ```
 
+To create a subtask, include the `parentTaskId` parameter:
+```json
+{
+  "name": "Research competitors",
+  "parentTaskId": "abc123",
+  "estimatedMinutes": 30
+}
+```
+
 ### omnifocus_complete_task
 Mark a task as complete or dropped.
 ```json
@@ -189,6 +200,25 @@ Get flagged tasks.
 {
   "includeCompleted": false,
   "limit": 50
+}
+```
+
+### omnifocus_get_subtasks
+Get all subtasks (children) of a specific task.
+```json
+{
+  "taskId": "abc123",
+  "includeCompleted": false,
+  "recursive": false
+}
+```
+
+For recursive retrieval of all nested descendants:
+```json
+{
+  "taskId": "abc123",
+  "recursive": true,
+  "maxDepth": 3
 }
 ```
 


### PR DESCRIPTION
## Summary

Adds comprehensive hierarchical task (subtask) support to the OmniFocus MCP server.

## Changes

- **Enhanced TaskData interface** with parent-child relationship fields:
  - `parentTaskId` and `parentTaskName` for tracking parent tasks
  - `hasChildren` and `childTaskCount` for tracking child tasks

- **Updated TASK_MAPPER** to extract parent and child task information from OmniFocus

- **Modified omnifocus_create_task** to support creating subtasks:
  - New `parentTaskId` parameter to specify parent task
  - Tasks can now be created as children of existing tasks

- **Added omnifocus_get_subtasks tool** for retrieving subtasks:
  - Supports recursive retrieval of all descendants
  - Optional maxDepth parameter to limit recursion
  - includeCompleted option for filtering
  - Returns depth level for each subtask

- **Updated README** with comprehensive documentation and examples

## Testing

After merging, test with:
1. Create a subtask using `omnifocus_create_task` with `parentTaskId`
2. Retrieve subtasks using `omnifocus_get_subtasks`
3. Verify parent-child relationships in returned task data

Fixes #1

Generated with [Claude Code](https://claude.ai/code)